### PR TITLE
Add simple Python game prototypes

### DIFF
--- a/game_prototypes/README.md
+++ b/game_prototypes/README.md
@@ -1,0 +1,25 @@
+# Game Prototypes
+
+This folder contains several small prototype games written in Python.
+
+## guess_number.py
+A simple number guessing game. The computer selects a random number between 1 and 100. Keep guessing until you get it right.
+
+Run with:
+```
+python3 guess_number.py
+```
+
+## rock_paper_scissors.py
+Classic Rock-Paper-Scissors against the computer.
+Run with:
+```
+python3 rock_paper_scissors.py
+```
+
+## tic_tac_toe.py
+Play Tic Tac Toe against a very simple CPU opponent.
+Run with:
+```
+python3 tic_tac_toe.py
+```

--- a/game_prototypes/guess_number.py
+++ b/game_prototypes/guess_number.py
@@ -1,0 +1,23 @@
+import random
+
+def main():
+    target = random.randint(1, 100)
+    attempts = 0
+    print("Guess the number between 1 and 100.")
+    while True:
+        try:
+            guess = int(input("Your guess: "))
+        except ValueError:
+            print("Enter a valid number.")
+            continue
+        attempts += 1
+        if guess == target:
+            print(f"Correct! Attempts: {attempts}")
+            break
+        elif guess < target:
+            print("Too low!")
+        else:
+            print("Too high!")
+
+if __name__ == "__main__":
+    main()

--- a/game_prototypes/rock_paper_scissors.py
+++ b/game_prototypes/rock_paper_scissors.py
@@ -1,0 +1,26 @@
+import random
+
+choices = ["rock", "paper", "scissors"]
+
+def main():
+    while True:
+        user = input("Rock, paper, or scissors? (q to quit) ").lower()
+        if user == 'q':
+            print("Bye!")
+            break
+        if user not in choices:
+            print("Invalid choice.")
+            continue
+        computer = random.choice(choices)
+        print("Computer chose:", computer)
+        if user == computer:
+            print("Tie!")
+        elif (user=='rock' and computer=='scissors') or \
+             (user=='paper' and computer=='rock') or \
+             (user=='scissors' and computer=='paper'):
+            print("You win!")
+        else:
+            print("You lose!")
+
+if __name__ == '__main__':
+    main()

--- a/game_prototypes/tic_tac_toe.py
+++ b/game_prototypes/tic_tac_toe.py
@@ -1,0 +1,67 @@
+import random
+
+board = [' ' for _ in range(9)]
+
+WIN_COMBOS = [
+    (0,1,2),(3,4,5),(6,7,8),
+    (0,3,6),(1,4,7),(2,5,8),
+    (0,4,8),(2,4,6)
+]
+
+def print_board():
+    print('\n'.join([
+        f" {board[i]} | {board[i+1]} | {board[i+2]} "
+        for i in range(0,9,3)
+    ]))
+
+
+def check_winner(sym):
+    return any(all(board[i]==sym for i in combo) for combo in WIN_COMBOS)
+
+
+def available_moves():
+    return [i for i,c in enumerate(board) if c==' ']
+
+
+def player_move():
+    while True:
+        try:
+            move = int(input("Choose position (1-9): "))-1
+            if move in available_moves():
+                board[move]='X'
+                break
+        except ValueError:
+            pass
+        print("Invalid move. Try again.")
+
+
+def cpu_move():
+    move = random.choice(available_moves())
+    board[move]='O'
+
+
+def main():
+    print("Tic Tac Toe - You are X, CPU is O")
+    while True:
+        print_board()
+        player_move()
+        if check_winner('X'):
+            print_board()
+            print("You win!")
+            break
+        if not available_moves():
+            print_board()
+            print("Draw!")
+            break
+        cpu_move()
+        if check_winner('O'):
+            print_board()
+            print("CPU wins!")
+            break
+        if not available_moves():
+            print_board()
+            print("Draw!")
+            break
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `game_prototypes` folder with mini-games
- implement `guess_number`, `rock_paper_scissors`, and `tic_tac_toe`
- document how to run the games

## Testing
- `python3 -m py_compile game_prototypes/*.py`
- `python3 game_prototypes/rock_paper_scissors.py <<EOF
q
EOF`
- `python3 game_prototypes/tic_tac_toe.py <<EOF
1
2
3
EOF`
- `python3 game_prototypes/guess_number.py <<EOF
1
2
3
4
5
EOF` *(fails: EOF when reading a line, expected due to early end of input)*

------
https://chatgpt.com/codex/tasks/task_e_68683fab04a4832b9104caa19d1f8d8f